### PR TITLE
CRAYSAT-1219 Allow arbitrary podman arguments to prodmgr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2023-07-12
+
+### Changed
+- Provide a new option --podman-options for users to provide arbitrary podman arguments to prodmgr.
+
 ## [1.2.0] - 2023-03-09
 
 ### Changed

--- a/prodmgr/main.py
+++ b/prodmgr/main.py
@@ -169,20 +169,27 @@ def run_deletion_utility(image_name, image_version, args, remaining_args):
     podman_command = [
         'podman', 'run', '--rm',
         '--mount', f'type=bind,src={args.kube_config_src_file},target={args.kube_config_target_file},ro=true',
-        '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true',
-        f'{args.container_registry_hostname}/{image_name}:{image_version}',
+        '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true']
+
+    if args.podman_options:
+        podman_options_command = args.podman_options.split(" ")
+        podman_command = podman_command + podman_options_command
+
+    container_command = [f'{args.container_registry_hostname}/{image_name}:{image_version}',
         args.action, args.product, args.version,
         # --product-catalog-name and --product-catalog-namespace are used both by this
         # script as well as with the underlying install utility image.
         f'--product-catalog-name={args.product_catalog_name}',
         f'--product-catalog-namespace={args.product_catalog_namespace}'
     ]
+    final_podman_command = podman_command + container_command
 
     # Pass any unrecognized CLI arguments to the container
-    podman_command.extend(remaining_args)
+    final_podman_command.extend(remaining_args)
+    print(f"Final podman command is - {final_podman_command}")
 
     try:
-        check_call(podman_command)
+        check_call(final_podman_command)
     except CalledProcessError as cpe:
         raise ProdmgrError(f'Running {image_name} failed: {cpe}')
 
@@ -203,17 +210,24 @@ def run_install_utility(image_name, image_version, args, remaining_args):
     podman_command = [
         'podman', 'run', '--rm',
         '--mount', f'type=bind,src={args.kube_config_src_file},target={args.kube_config_target_file},ro=true',
-        '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true',
-        f'{args.container_registry_hostname}/{image_name}:{image_version}',
+        '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true']
+
+    if args.podman_options:
+        podman_options_command = args.podman_options.split(" ")
+        podman_command = podman_command + podman_options_command
+
+    container_command = [f'{args.container_registry_hostname}/{image_name}:{image_version}',
         args.action, args.version,
         # --product-catalog-name and --product-catalog-namespace are used both by this
         # script as well as with the underlying install utility image.
         f'--product-catalog-name={args.product_catalog_name}',
         f'--product-catalog-namespace={args.product_catalog_namespace}'
     ]
+    final_podman_command = podman_command + container_command
 
     # Pass any unrecognized CLI arguments to the container
-    podman_command.extend(remaining_args)
+    final_podman_command.extend(remaining_args)
+    print(f"Final podman command is - {final_podman_command}")
 
     try:
         check_call(podman_command)

--- a/prodmgr/main.py
+++ b/prodmgr/main.py
@@ -171,9 +171,8 @@ def run_deletion_utility(image_name, image_version, args, remaining_args):
         '--mount', f'type=bind,src={args.kube_config_src_file},target={args.kube_config_target_file},ro=true',
         '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true']
 
-    if args.podman_options:
-        podman_options_command = args.podman_options.split(" ")
-        podman_command = podman_command + podman_options_command
+    if args.extra_podman_config:
+        podman_command = podman_command + args.extra_podman_config.split(" ")
 
     container_command = [f'{args.container_registry_hostname}/{image_name}:{image_version}',
         args.action, args.product, args.version,
@@ -182,14 +181,14 @@ def run_deletion_utility(image_name, image_version, args, remaining_args):
         f'--product-catalog-name={args.product_catalog_name}',
         f'--product-catalog-namespace={args.product_catalog_namespace}'
     ]
-    final_podman_command = podman_command + container_command
+    deletion_utility_command = podman_command + container_command
 
     # Pass any unrecognized CLI arguments to the container
-    final_podman_command.extend(remaining_args)
-    print(f"Final podman command is - {final_podman_command}")
+    deletion_utility_command.extend(remaining_args)
+    print(f"Launching deletion utility using - {deletion_utility_command}")
 
     try:
-        check_call(final_podman_command)
+        check_call(deletion_utility_command)
     except CalledProcessError as cpe:
         raise ProdmgrError(f'Running {image_name} failed: {cpe}')
 
@@ -212,9 +211,8 @@ def run_install_utility(image_name, image_version, args, remaining_args):
         '--mount', f'type=bind,src={args.kube_config_src_file},target={args.kube_config_target_file},ro=true',
         '--mount', f'type=bind,src={args.cert_src_dir},target={args.cert_target_dir},ro=true']
 
-    if args.podman_options:
-        podman_options_command = args.podman_options.split(" ")
-        podman_command = podman_command + podman_options_command
+    if args.extra_podman_config:
+        podman_command = podman_command + args.extra_podman_config.split(" ")
 
     container_command = [f'{args.container_registry_hostname}/{image_name}:{image_version}',
         args.action, args.version,
@@ -223,14 +221,14 @@ def run_install_utility(image_name, image_version, args, remaining_args):
         f'--product-catalog-name={args.product_catalog_name}',
         f'--product-catalog-namespace={args.product_catalog_namespace}'
     ]
-    final_podman_command = podman_command + container_command
+    install_utility_command = podman_command + container_command
 
     # Pass any unrecognized CLI arguments to the container
-    final_podman_command.extend(remaining_args)
-    print(f"Final podman command is - {final_podman_command}")
+    install_utility_command.extend(remaining_args)
+    print(f"Launching install utility using - {install_utility_command}")
 
     try:
-        check_call(final_podman_command)
+        check_call(install_utility_command)
     except CalledProcessError as cpe:
         raise ProdmgrError(f'Running {image_name} failed: {cpe}')
 
@@ -268,3 +266,4 @@ def main(*args):
 
 if "__main__" == __name__:
     main()
+

--- a/prodmgr/main.py
+++ b/prodmgr/main.py
@@ -230,7 +230,7 @@ def run_install_utility(image_name, image_version, args, remaining_args):
     print(f"Final podman command is - {final_podman_command}")
 
     try:
-        check_call(podman_command)
+        check_call(final_podman_command)
     except CalledProcessError as cpe:
         raise ProdmgrError(f'Running {image_name} failed: {cpe}')
 

--- a/prodmgr/parser.py
+++ b/prodmgr/parser.py
@@ -115,4 +115,10 @@ def create_parser():
         default=None,
     )
 
+    parser.add_argument(
+        '--podman-options',
+        help='Arbitrary podman options to be provided as a string while using deletion image(Eg: --podman-options "--mount /tmp/ --rm --name deletion-container")',
+        default=None,
+    )
+
     return parser

--- a/prodmgr/parser.py
+++ b/prodmgr/parser.py
@@ -116,8 +116,8 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--podman-options',
-        help='Arbitrary podman options to be provided as a string while using deletion image(Eg: --podman-options "--mount /tmp/ --rm --name deletion-container")',
+        '--extra-podman-config',
+        help='Additional podman options when launching the deletion/install utility using podman container engine(Eg: --extra-podman-config "--mount type=bind,src=<src>,target=<target> --no-hosts --name deletion-container")',
         default=None,
     )
 


### PR DESCRIPTION
## Summary and Scope

As a user of prodmgr, I want to pass extra arguments to podman (e.g. another directory to mount using --mount), so that I can use prodmgr without having to update prodmgr itself, even when the system may have changed. 
For this, added an option to prodmgr called --podman-options which are passed to the podman invocation in prodmgr.

Usage of prodmgr with new option '--podman-options' whose value needs to be provided as a string in double quotes : 
`prodmgr delete cos 2.99 --podman-options "--mount type=bind,src=<src>,target=<target> --no-hosts --name deletion-container" --container-registry-hostname arti.hpc.amslabs.hpecorp.net/csm-docker-remote/unstable --deletion-image-name product-deletion-utility --deletion-image-version 0.0.1-20230606211511_d9607b0`

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1219](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1219)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

### Tested on:

  * `MUG`
  * Local development environment
  * Virtual Shasta

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

