### PR TITLE
Adding the final version of default product-deletion-utility to be used

### DIFF
--- a/prodmgr/parser.py
+++ b/prodmgr/parser.py
@@ -107,7 +107,7 @@ def create_parser():
     parser.add_argument(
         '--deletion-image-version',
         help='The version of the deletion image',
-        default='0.0.0-product-deletion-utility',
+        default='1.0.0',
     )
     parser.add_argument(
         '--csm-version',

--- a/prodmgr/parser.py
+++ b/prodmgr/parser.py
@@ -107,7 +107,7 @@ def create_parser():
     parser.add_argument(
         '--deletion-image-version',
         help='The version of the deletion image',
-        default='1.0.0',
+        default='0.0.0',
     )
     parser.add_argument(
         '--csm-version',

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -79,6 +79,6 @@
 # no images will be found.
 
 image: product-deletion-utility
-    major: 0
+    major: 1
 #    minor:
 

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -24,6 +24,6 @@
 # The following file does not exist in the repo as a static file.
 # It is generated at build time
 sourcefile: product-deletion-utility.version
-tag: 0.0.0-product-deletion-utility
+tag: 1.0.0
 targetfile: prodmgr/parser.py
 

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -24,6 +24,6 @@
 # The following file does not exist in the repo as a static file.
 # It is generated at build time
 sourcefile: product-deletion-utility.version
-tag: 1.0.0
+tag: 0.0.0
 targetfile: prodmgr/parser.py
 


### PR DESCRIPTION
## Summary and Scope

Final changes for CASM-3723 epic which includes modifications for adding default product-deletion-utility to be used.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Completes CASM-3723 (https://jira-pro.it.hpe.com:8443/browse/CASM-3723)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `MUG`
  * Local development environment
  * Virtual Shasta

### Test description:

Executed tests that span prodmgr and product-deletion-utility.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

