### PR TITLE
Fix license check

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,11 +37,11 @@ jobs:
           password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v45
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Summary and Scope

Update versions of `checkout` and `tj-actions/changed-files` actions, which became out of date.
